### PR TITLE
Setting AllStar branch protection to fix and enforcing it on admins.

### DIFF
--- a/branch_protection.yaml
+++ b/branch_protection.yaml
@@ -1,3 +1,4 @@
 optConfig:
   optOutStrategy: true
-action: issue
+action: fix
+enforceOnAdmins: true


### PR DESCRIPTION
This way, branch protection will be applied to all repositories by allstar.