### PR TITLE
Opting private repos out of allstar

### DIFF
--- a/outside.yaml
+++ b/outside.yaml
@@ -1,3 +1,6 @@
 optConfig:
   optOutStrategy: true
+  optOutRepos:
+  - .allstar
+  - kokoro-integration-test
 action: issue


### PR DESCRIPTION
Allstar cannot add branch protection to private repos, so the associated tickets can't be closed.

Since we aren't planning on allowing private repos in general, this should be safe.